### PR TITLE
feat(core): Use prettier v1, update babel configs

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -2,7 +2,6 @@
   "plugins": [
     ["transform-object-rest-spread", { "useBuiltIns": true }],
     ["fast-async", {
-      "runtimePatten": null,
       "compiler": {
         "promises": true,
         "es7": true,

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
+  "plugins": [
+    ["transform-object-rest-spread", { "useBuiltIns": true }]
+  ],
   "presets": [
-    ["node-module"]
+    ["env", {
+      "targets": {
+        "node": true
+      }
+    }]
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,16 @@
 {
   "plugins": [
-    ["transform-object-rest-spread", { "useBuiltIns": true }]
+    ["transform-object-rest-spread", { "useBuiltIns": true }],
+    ["fast-async", {
+      "runtimePatten": null,
+      "compiler": {
+        "promises": true,
+        "es7": true,
+        "noRuntime": true,
+        "wrapAwait": true,
+        "generators": false
+      }
+    }]
   ],
   "presets": [
     ["env", {

--- a/.babelrc
+++ b/.babelrc
@@ -6,7 +6,6 @@
       "compiler": {
         "promises": true,
         "es7": true,
-        "noRuntime": true,
         "wrapAwait": true,
         "generators": false
       }
@@ -16,7 +15,8 @@
     ["env", {
       "targets": {
         "node": 4.8
-      }
+      },
+      "exclude": ["transform-async-to-generator"]
     }]
   ]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,7 @@
   "presets": [
     ["env", {
       "targets": {
-        "node": true
+        "node": 4.8
       }
     }]
   ]

--- a/.babelrc
+++ b/.babelrc
@@ -16,7 +16,10 @@
       "targets": {
         "node": 4.8
       },
-      "exclude": ["transform-async-to-generator"]
+      "exclude": [
+        "transform-async-to-generator",
+        "transform-regenerator"
+      ]
     }]
   ]
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "babel-preset-env": "^1.4.0",
     "babel-register": "^6.23.0",
     "cross-run": "^1.0.1",
+    "fast-async": "^6.2.2",
     "husky": "^0.13.2",
     "jest": "^19.0.2",
     "lint-staged": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "babel-runtime": "^6.23.0",
     "chalk": "^1.1.3",
+    "eslint": "*",
     "find-up": "^2.1.0",
     "get-stdin": "^5.0.1",
     "glob": "^7.1.1",
@@ -26,20 +27,20 @@
     "loglevel-colored-level-prefix": "^1.0.0",
     "meow": "3.7.0",
     "messageformat": "^1.0.2",
-    "prettier-eslint": "^4.3.2",
-    "eslint": "*",
+    "prettier-eslint": "^5.1.0",
     "rxjs": "^5.2.0"
   },
   "devDependencies": {
     "babel-cli": "^6.23.0",
     "babel-jest": "^19.0.0",
-    "babel-preset-node-module": "^1.2.1",
+    "babel-plugin-transform-object-rest-spread": "^6.23.0",
+    "babel-preset-env": "^1.4.0",
     "babel-register": "^6.23.0",
     "cross-run": "^1.0.1",
     "husky": "^0.13.2",
     "jest": "^19.0.2",
     "lint-staged": "^3.3.1",
-    "prettier": "^0.22.0",
+    "prettier": "^1.0.2",
     "rimraf": "^2.6.1"
   },
   "scripts": {

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -55,6 +55,10 @@ async function formatFilesFromArgv (
     logLevel,
     eslintPath,
     prettierPath,
+    prettierConfig: {
+      singleQuote: false,
+      semi: true
+    },
     eslintConfig: {
       parserOptions: {
         ecmaVersion: 8,

--- a/src/format-files.js
+++ b/src/format-files.js
@@ -56,7 +56,7 @@ async function formatFilesFromArgv (
     eslintPath,
     prettierPath,
     prettierConfig: {
-      singleQuote: false,
+      singleQuote: true,
       semi: true
     },
     eslintConfig: {

--- a/src/format-files.test.js
+++ b/src/format-files.test.js
@@ -113,11 +113,7 @@ test('logs errors to the console if something goes wrong', async () => {
   const cliError = expect.stringContaining('eslint-config-error')
   const errorOutput = expect.stringContaining('Some weird eslint config error')
   expect(console.error).toHaveBeenCalledTimes(4)
-  expect(console.error).toHaveBeenCalledWith(
-    errorPrefix,
-    cliError,
-    errorOutput
-  )
+  expect(console.error).toHaveBeenCalledWith(errorPrefix, cliError, errorOutput)
 })
 
 test('forwards logLevel onto prettier-eslint', async () => {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ const cli = meow(
   Examples
     $ prettier-standard 'src/**/*.js'
     $ echo "const {foo} = "bar";" | prettier-standard
- 
+
 `
 )
 


### PR DESCRIPTION
 - (deps) updates pretter-eslint to v5+ (prettier v1 engine)
 - (feature) use prettier AST formatter for handling `semi` and `single-quotes`
 - (babel) replace `preset-node-module` with `preset-env`
 - (babel) use `fast-async` promise for async/await control flow in node v4 LTS
 - (babel) remove unnecessary runtime dependencies (ie `regeneratorRuntime`)

resolves #3 

shouldn't be any breaking changes, could ship a patch release :)