### PR TITLE
Add pre-commit script to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,10 @@ Typically you'll use this in your [npm scripts][npm scripts] (or [package script
 We also encourage to use [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged). You can configure it as follows:
 
 ```json
-{
+{ 
+  "scripts":{
+    "precommit": "lint-staged"
+  },
   "lint-staged": {
     "linters": {
       "src/**/*.js": [


### PR DESCRIPTION
When I was setting up prettier-standard in my project, I got stuck when following the current example in the README. Because no pre-commit script was included in the example, I never included it, and then could not figure out why my git hooks weren't running.

I know this problem isn't specific to prettier-standard, but because you're providing example, I think it should be more fleshed out.

I also wrote a [blog post](https://medium.com/@MCapoz/keep-your-codebase-neat-and-tidy-with-prettier-standard-lint-staged-and-husky-9f9a6b1d4f72) with an example of how to set this up, if that would be useful for this README.