### PR TITLE
Encourage using standard in lint-staged

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ Typically you'll use this in your [npm scripts][npm scripts] (or [package script
 }
 ```
 
-We also encourage to use [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged). You can configure it as follows:
+We also encourage to use [husky](https://github.com/typicode/husky) and [lint-staged](https://github.com/okonet/lint-staged). You should also still use [standard](https://github.com/feross/standard) if you want to check for other not fixable rules like `no-unused-vars`, etc. 
+
+You can configure it as follows:
 
 ```json
 { 
@@ -51,6 +53,7 @@ We also encourage to use [husky](https://github.com/typicode/husky) and [lint-st
     "linters": {
       "src/**/*.js": [
         "prettier-standard",
+        "standard --fix"
         "git add"
       ]
     }


### PR DESCRIPTION
Hopefully this will make it a bit more clear that `prettier-standard` is not a complete replacement of `standard`, and that you should still use `standard` if you want to check all the rules. 

Should help with issues like https://github.com/sheerun/prettier-standard/issues/53 and https://github.com/sheerun/prettier-standard/issues/17#issuecomment-336444681.

Thanks for creating and maintaining such a useful project!