### PR TITLE
Add "npm init prettier-standard" to the installation instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ yarn add --dev prettier-standard
 
 > If you're using the [`npm`][npm]: `npm install --save-dev prettier-standard`.
 
-> You can also install globally with `npm install -g prettier-standard`
+> You can also install globally with `npm install -g prettier-standard`.
+
+> For existing projects, if you have NPM >= 6.1.0, use `npm init prettier-standard` to easily add prettier-standard with [create-prettier-standard](https://github.com/JustinDFuller/create-prettier-standard).
 
 ## Usage
 


### PR DESCRIPTION
As of NPM version 6.1.0 you can run `npm init <initializer>` that will use `npx create-<initializer>` to initialize an app. I've created a prettier-standard initializer based on the instructions provided here in this document (including husky and lint-staged).