### PR TITLE
Remove nope

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -8,7 +8,6 @@ function getPathInHostNodeModules (module) {
   if (modulePath) {
     return modulePath
   }
-  console.log('nope')
 
   const result = findUp.sync(`node_modules/${module}`, {
     cwd: __dirname,


### PR DESCRIPTION
console.log('nope') causes nope to be printed in formatted files