### PR TITLE
Allow override eslint parser

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -121,9 +121,9 @@ async function run (cwd, config) {
 
     const eslint = require(eslintPath)
     engine = new eslint.CLIEngine({
-      parser: babelEslintPath,
       resolvePluginsRelativeTo: path.join(__dirname, 'vendor'),
       baseConfig: {
+        parser: babelEslintPath,
         plugins: ['jest'],
         env: {
           'jest/globals': true


### PR DESCRIPTION
Fixes #112

Makes this honor custom `parser` field in `.eslintrc`.