### PR TITLE
Use case-insensitive matching for Git error "Not a valid object name"

### DIFF
--- a/src/scms/git.js
+++ b/src/scms/git.js
@@ -52,7 +52,7 @@ class Git {
       if (error.stderr) {
         if (
           error.stderr.includes(`Needed a single revision`) ||
-          error.stderr === 'fatal: Not a valid object name HEAD'
+          error.stderr.toLowerCase().includes('not a valid object name')
         ) {
           return SPECIAL_EMPTY_TREE_COMMIT_HASH
         }


### PR DESCRIPTION
Fixes #152

Git is lowercasing the `fatal: Not a valid object name` error message
to follow its CodingGuidelines. This change makes the string matching
case-insensitive so it works with both the current and future Git versions.

Changes:
- Replace exact string equality with case-insensitive `.toLowerCase().includes()` check

See: https://lore.kernel.org/git/pull.2052.git.1771836302101.gitgitgadget@gmail.com